### PR TITLE
Barometer driver improvements

### DIFF
--- a/avionics/MS5803_01.cpp
+++ b/avionics/MS5803_01.cpp
@@ -293,19 +293,19 @@ unsigned long MS_5803::MS_5803_ADC(char commandADC) {
     switch (commandADC & 0x0F)
     {
         case CMD_ADC_256 :
-            delay(1); // 1 ms
+            delayMicroseconds(650); // 1 ms
             break;
         case CMD_ADC_512 :
-            delay(3); // 3 ms
+            delayMicroseconds(1220); // 3 ms
             break;
         case CMD_ADC_1024:
-            delay(4);
+            delayMicroseconds(2330);
             break;
         case CMD_ADC_2048:
-            delay(6);
+            delayMicroseconds(4590);
             break;
         case CMD_ADC_4096:
-            delay(10);
+            delayMicroseconds(9090);
             break;
     }
     // Now send the read command to the MS5803

--- a/avionics/MS5803_01.h
+++ b/avionics/MS5803_01.h
@@ -41,7 +41,7 @@ public:
     // Reset the sensor
     bool resetSensor();
     // Read the sensor
-    void readSensor();
+    bool readSensor();
     //*********************************************************************
     // Additional methods to extract temperature, pressure (mbar), and the
     // D1,D2 values after readSensor() has been called
@@ -69,6 +69,8 @@ private:
 
     float mbar; // Store pressure in mbar.
     float tempC; // Store temperature in degrees Celsius
+
+    bool _transmitSuccess; //true normally, false if transmission failed at some point
 //    float tempF; // Store temperature in degrees Fahrenheit
 //    float psiAbs; // Store pressure in pounds per square inch, absolute
 //    float psiGauge; // Store gauge pressure in pounds per square inch (psi)

--- a/avionics/MS5803_01.h
+++ b/avionics/MS5803_01.h
@@ -2,25 +2,25 @@
  * 	An Arduino library for the Measurement Specialties MS5803 family
  * 	of pressure sensors. This library uses I2C to communicate with the
  * 	MS5803 using the Wire library from Arduino.
- *	
+ *
  *	This library only works with the MS5803-14BA model sensor. It DOES NOT
  *	work with the other pressure-range models such as the MS5803-30BA or
- *	MS5803-01BA. Those models will return incorrect pressure and temperature 
+ *	MS5803-01BA. Those models will return incorrect pressure and temperature
  *	readings if used with this library. See http://github.com/millerlp for
- *	libraries for the other models. 
- *	 
- * 	No warranty is given or implied. You are responsible for verifying that 
+ *	libraries for the other models.
+ *
+ * 	No warranty is given or implied. You are responsible for verifying that
  *	the outputs are correct for your sensor. There are likely bugs in
  *	this code that could result in incorrect pressure readings, particularly
- *	due to variable overflows within some pressure ranges. 
- * 	DO NOT use this code in a situation that could result in harm to you or 
+ *	due to variable overflows within some pressure ranges.
+ * 	DO NOT use this code in a situation that could result in harm to you or
  * 	others because of incorrect pressure readings.
- * 	 
- * 	
- * 	Licensed under the GPL v3 license. 
- * 	Please see accompanying LICENSE.md file for details on reuse and 
+ *
+ *
+ * 	Licensed under the GPL v3 license.
+ * 	Please see accompanying LICENSE.md file for details on reuse and
  * 	redistribution.
- * 	
+ *
  * 	Copyright Luke Miller, April 1 2014
  */
 
@@ -32,22 +32,22 @@
 
 class MS_5803 {
 public:
-	// Constructor for the class. 
-	// The argument is the desired oversampling resolution, which has 
+	// Constructor for the class.
+	// The argument is the desired oversampling resolution, which has
 	// values of 256, 512, 1024, 2048, 4096
     MS_5803(uint16_t Resolution = 512);
-    // Initialize the sensor 
+    // Initialize the sensor
     boolean initializeMS_5803(boolean Verbose = true);
     // Reset the sensor
-    void resetSensor();
+    bool resetSensor();
     // Read the sensor
     void readSensor();
     //*********************************************************************
-    // Additional methods to extract temperature, pressure (mbar), and the 
+    // Additional methods to extract temperature, pressure (mbar), and the
     // D1,D2 values after readSensor() has been called
-    
+
     // Return temperature in degrees Celsius.
-    float temperature() const       {return tempC;}  
+    float temperature() const       {return tempC;}
     // Return pressure in mbar.
     float pressure() const          {return mbar;}
 //    // Return temperature in degress Fahrenheit.
@@ -63,11 +63,11 @@ public:
     // Return the D1 and D2 values, mostly for troubleshooting
     unsigned long D1val() const 	{return D1;}
     unsigned long D2val() const		{return D2;}
-    
-    
+
+
 private:
-    
-    float mbar; // Store pressure in mbar. 
+
+    float mbar; // Store pressure in mbar.
     float tempC; // Store temperature in degrees Celsius
 //    float tempF; // Store temperature in degrees Fahrenheit
 //    float psiAbs; // Store pressure in pounds per square inch, absolute
@@ -78,11 +78,11 @@ private:
     unsigned long D2;	// Store D2 value
     int32_t mbarInt; // pressure in mbar, initially as a signed long integer
     // Check data integrity with CRC4
-    unsigned char MS_5803_CRC(unsigned int n_prom[]); 
+    unsigned char MS_5803_CRC(unsigned int n_prom[]);
     // Handles commands to the sensor.
     unsigned long MS_5803_ADC(char commandADC);
     // Oversampling resolution
     uint16_t _Resolution;
 };
 
-#endif 
+#endif

--- a/avionics/sensors.cpp
+++ b/avionics/sensors.cpp
@@ -71,8 +71,15 @@ bool initSensors(void)
     #endif
     //barometer.reset();
     //barometer.begin();
-    barometer.initializeMS_5803(false); //true if Serial Print Everything
-
+    #ifdef TESTING
+    if (!barometer.initializeMS_5803(true)) {
+        return false;
+    }
+    #else
+    if (!barometer.initializeMS_5803(false)) {
+        return false;
+    }
+    #endif
 
     /*init temp sensor*/
     #ifdef TESTING

--- a/avionics/sensors.cpp
+++ b/avionics/sensors.cpp
@@ -163,7 +163,12 @@ void pollSensors(unsigned long *timestamp, float acc_data[], float bar_data[],
     #ifdef TESTING
     SerialUSB.println("Polling barometer");
     #endif
-    barometer.readSensor();
+    bool bar_flag = barometer.readSensor();
+
+    #ifdef TESTING
+    if(!bar_flag)
+        SerialUSB.println("BAROMETER FAILED READING");
+    #endif
     //bar_data[0] = barometer.getPressure(ADC_4096);
     //bar_data[1] = barometer.getTemperature(CELSIUS, ADC_512);
     bar_data[0] = barometer.pressure();


### PR DESCRIPTION
Now:
-returns flag for whether initialization was successful
-returns flag for whether data was read successfully 

Code has been tested by taking the barometer out and putting it back in a couple of times. A couple of #ifdef statements are left in so the Serial output might be different when debugging.