### PR TITLE
Camera turned on in critical failure

### DIFF
--- a/avionics/avionics.ino
+++ b/avionics/avionics.ino
@@ -111,6 +111,8 @@ void setup()
     /*init camera serial port*/
     SerialCamera.begin(CameraBaud);
     while (!SerialCamera) {}
+    if(s_statusOfInit.overview == CRITICAL_FAILURE)
+        start_record();
 
     /* init various arrays */
     baseline_pressure = barSensorInit(); /* for baseline pressure calculation */


### PR DESCRIPTION
This is something that's been lying around and apparently I never pushed it. Just 2 lines that turn on the camera in the critical failure mode. I skimmed over dev and I don't think I saw something of this effect