### PR TITLE
Enabled PlatformIO builds in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ sudo: required
 install:
 - sudo apt-get update -y
 
+# PlatformIO
+- pip install -U platformio
+- pio update
+
 # Needed for unit testing with qt https://github.com/pytest-dev/pytest-qt/issues/293
 - sudo apt-get install -y xvfb libxkbcommon-x11-0
 - sudo Xvfb :1 -screen 0 1024x768x24 </dev/null &
@@ -32,6 +36,11 @@ install:
 - cd ../FLARE
 
 script:
+# PlatformIO build
+# TODO: build all envs once possible
+- pio run --environment tantalus_stage_1
+
+# Build and unittest on x86
 - mkdir avionics/build
 - cd avionics/build
 - cmake ..

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,7 +39,7 @@ build_flags =
     -I avionics/envs/board/include
     -I avionics/envs/board/lib
 
-src_build_flags = !python custom_tools/git_rev_macro.py
+src_build_flags = !python3 custom_tools/git_rev_macro.py
 ; src_build_flags =
 ;     -D RADIO_CONFIG_PACKET_VERSION_STR=\"test\"
 


### PR DESCRIPTION
Added PlatformIO builds to CI. Currently only doing TantalusStage1. We should remember to enable the others once possible. Hopefully this will ensure that we never break anything teensy specific.

Also I tested and verified that the pio build fails if we use more memory/ram than is available on the teensy. This is good because now CI is effectively testing our memory usage as well.

I wrote some notes about how to use PIO from command line here: http://confluence.ubcrocket.com/display/AV/Using+PlatformIO+from+commandline