### PR TITLE
Fix radio packet double read bug

### DIFF
--- a/avionics/common/include/radio.h
+++ b/avionics/common/include/radio.h
@@ -108,12 +108,13 @@ class RadioController {
             can_receive_command<Actor>::value,
             "act_upon does not have the expected signature void(uint8_t)");
 
-        xbee_.readPacket();
         int read_count = 0;
-
-        while ((xbee_.getResponse().isAvailable() ||
-                xbee_.getResponse().isError())) {
-            // goes through all xbee_ packets in buffer
+        while (read_count < MAX_PACKETS_PER_RX_LOOP_) {
+            xbee_.readPacket();
+            if (!(xbee_.getResponse().isAvailable() ||
+                  xbee_.getResponse().isError())) {
+                break;
+            }
 
             if (xbee_.getResponse().isError()) {
                 // TODO - figure out whether there's anything
@@ -139,10 +140,6 @@ class RadioController {
             }
 
             read_count++;
-            if (read_count >= MAX_PACKETS_PER_RX_LOOP_) {
-                break;
-            }
-            xbee_.readPacket();
         }
         if (Hal::now_ms() - watchdog_last_send_ > WATCHDOG_SEND_INTERVAL_) {
             can_send = true;

--- a/avionics/common/include/radio.h
+++ b/avionics/common/include/radio.h
@@ -109,10 +109,9 @@ class RadioController {
             "act_upon does not have the expected signature void(uint8_t)");
 
         xbee_.readPacket();
-        int i = 0;
+        int read_count = 0;
 
-        while (i < MAX_PACKETS_PER_RX_LOOP_ &&
-               (xbee_.getResponse().isAvailable() ||
+        while ((xbee_.getResponse().isAvailable() ||
                 xbee_.getResponse().isError())) {
             // goes through all xbee_ packets in buffer
 
@@ -139,8 +138,11 @@ class RadioController {
                 // extra one, so we shouldn't respond twice again.
             }
 
+            read_count++;
+            if (read_count >= MAX_PACKETS_PER_RX_LOOP_) {
+                break;
+            }
             xbee_.readPacket();
-            i++;
         }
         if (Hal::now_ms() - watchdog_last_send_ > WATCHDOG_SEND_INTERVAL_) {
             can_send = true;


### PR DESCRIPTION
Note that if neither `getResponse().isAvailable()` or `...isError()` is true, then there are no more packets, and when you need to read again you must call `xbee_.readPacket()` again.