### PR TITLE
Remove use of SubPktPtr

### DIFF
--- a/avionics/common/include/radio.h
+++ b/avionics/common/include/radio.h
@@ -32,27 +32,6 @@
 #include "sensors/IMU.h"
 #include "sensors/accelerometer.h"
 #include "state_id_enum.hpp"
-#include "subpktptr.h"
-
-class PacketBuffWriter {
-  public:
-    PacketBuffWriter() : packet(new std::vector<uint8_t>) {
-        packet->reserve(255); // To avoid overhead of resizing multiple times
-    }
-
-    void write(void const *data, size_t size) {
-        if (!packet)
-            return;
-
-        size_t old_size = packet->size();
-        packet->resize(old_size + size);
-        std::memcpy(packet->data() + old_size, data, size);
-    }
-
-    void write(uint8_t byte) { write(&byte, 1); }
-
-    SubPktPtr packet;
-};
 
 class Radio {
   private:
@@ -137,15 +116,16 @@ class Radio {
         }
     }
 
-    /**
-     * @brief Add a subpacket to the queue to be sent. Note that this is a
-     * rather low-level utility; there should also be a helper method for any
-     * given subpacket that will build up the specific format this needs that
-     * you should use instead. Note that due to move semantics you will likely
-     * need to use std::move(dat).
-     * @param dat A SubPktPtr (refer to typedef) containing the data.
-     */
-    static void addSubpacket(SubPktPtr dat);
+    // /**
+    //  * @brief Add a subpacket to the queue to be sent. Note that this is a
+    //  * rather low-level utility; there should also be a helper method for any
+    //  * given subpacket that will build up the specific format this needs that
+    //  * you should use instead. Note that due to move semantics you will
+    //  likely
+    //  * need to use std::move(dat).
+    //  * @param dat A SubPktPtr (refer to typedef) containing the data.
+    //  */
+    // static void addSubpacket(SubPktPtr dat);
 
     /**
      * @brief Helper function to send status.
@@ -235,10 +215,7 @@ class Radio {
      * raw pointer rather than a unique pointer, so you'll need to call the
      * get() method of SubPktPtr.
      */
-    static void addIdTime(PacketBuffWriter &buf, Ids id, uint32_t time) {
-        buf.write(static_cast<uint8_t>(id));
-        buf.write(&time, sizeof(time));
-    }
+    static void addIdTime(Ids id, uint32_t time);
 
     /**
      * @brief Actually writes out data to the radio serial line; this is done

--- a/avionics/common/include/subpktptr.h
+++ b/avionics/common/include/subpktptr.h
@@ -1,4 +1,0 @@
-// Purpose of this file is to help separate implementation from interface
-#include <memory> // for std::unique_ptr
-#include <vector> // for std::vector
-typedef std::unique_ptr<std::vector<uint8_t>> SubPktPtr;

--- a/avionics/common/src/roar/buffer.cpp
+++ b/avionics/common/src/roar/buffer.cpp
@@ -1,5 +1,4 @@
 #include <cassert>
-#include <cstring> // memcpy
 
 #include "roar/buffer.hpp"
 
@@ -89,23 +88,6 @@ void Buffer::write(uint8_t byte) {
 
     deref(pos_) = byte;
     pos_ = addIt(pos_, 1);
-}
-
-void Buffer::write(uint8_t *dat, int len) {
-    // make sure that we haven't overflowed the allocated space for a subpkt
-    assert(subIt(deref(addIt(subpkt_begin_, subpkt_count_)), pos_) >= len);
-
-    int space_remain = data_cap_ - pos_.index;
-    if (len <= space_remain) {
-        // fits within remaining space
-        std::memcpy(&data_[pos_.index], dat, len);
-    } else {
-        // data wraps to start
-        std::memcpy(&data_[pos_.index], dat, space_remain);
-        std::memcpy(data_.get(), dat + space_remain, len - space_remain);
-    }
-
-    pos_ = addIt(pos_, len);
 }
 
 /**


### PR DESCRIPTION
Finishes the job of #158 by actually removing usage of `<vector>` and things that use dynamic memory management.