### PR TITLE
Radio buffer bugfix

### DIFF
--- a/avionics/common/include/roar/buffer.hpp
+++ b/avionics/common/include/roar/buffer.hpp
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 #include <cstring> // memcpy
-#include <memory> // unique_ptr, used for fixed internal buffers on the heap
+#include <memory>  // unique_ptr, used for fixed internal buffers on the heap
 namespace roar {
 
 /**
@@ -25,6 +25,7 @@ namespace roar {
 class Buffer {
   public:
     /**
+     * @param pkt_size Size (in bytes) of one subpacket; used in fillPayload.
      * @param data_capacity Space (in bytes) for the underlying buffer.
      * @param subpkt_capacity Maximum number of subpackets to keep track
      * of. Should be less than data_capacity.
@@ -69,8 +70,8 @@ class Buffer {
 
     /**
      * @brief Fills payload pointer as full as possible (i.e. at most
-     * RADIO_MAX_PACKET_SIZE bytes)
-     * @param payload Pointer to payload array.
+     * pkt_size bytes, where pkt_size is what was passed into the constructor)
+     * @param payload Pointer to payload array. Must be at least pkt_size long.
      * @return Size of payload data filled in.
      */
     int fillPayload(uint8_t *payload);

--- a/avionics/tests/unit_Roar.cpp
+++ b/avionics/tests/unit_Roar.cpp
@@ -333,3 +333,36 @@ TEST(RoarBuffer, WrapWrite3) {
         EXPECT_EQ(payload[i], i);
     }
 }
+
+/**
+ * Test position reseting behaviour of internal dumpContiguous strategy
+ */
+TEST(RoarBuffer, DumpContiguousResetting) {
+    roar::Buffer buff(8, 32, 8);
+
+    // Write 16 subpackets of size 1
+    for (int i = 0; i < 16; ++i) {
+        buff.allocSubpkt(1);
+        buff.write(i + 1);
+    }
+
+    // Since only 8 subpackets allowed to be stored at a time, only 8 bytes of
+    // data used
+    EXPECT_EQ(buff.usage(), 8);
+
+    std::vector<uint8_t> payload(10, 255);
+    // should use the dumpContiguous approach
+    buff.fillPayload(payload.data());
+
+    // buffer is now empty
+    EXPECT_EQ(buff.usage(), 0);
+
+    buff.allocSubpkt(3);
+    buff.write(100);
+    buff.write(101);
+    buff.write(102);
+    buff.allocSubpkt(3);
+    buff.write(103);
+    buff.write(104);
+    buff.write(105);
+}


### PR DESCRIPTION
Fixes a bug in radio buffer implementation. Bug came from not fully resetting all variables after dumping the entire buffer queue. Added test to address this, and simplified the logic to avoid the issue entirely.
