### PR TITLE
Fixed platformio compile warning about non-void missing return

### DIFF
--- a/avionics/envs/board/lib/HAL/port_impl.h
+++ b/avionics/envs/board/lib/HAL/port_impl.h
@@ -13,7 +13,7 @@ class Serial {
     void begin(long baud) { m_seri.begin(baud); }
     bool available() { return m_seri.available(); }
     int read() { return m_seri.read(); }
-    std::size_t write(uint8_t val) { m_seri.write(val); }
+    std::size_t write(uint8_t val) { return m_seri.write(val); }
     std::size_t write(const uint8_t *buffer, size_t size) {
         return m_seri.write(buffer, size);
     };


### PR DESCRIPTION
I feel like this might have actually been a serious bug:
```
In file included from avionics/common/include/XBee.h:47:0,
                 from avionics/common/src/XBee.cpp:38:
avionics/envs/board/lib/HAL/port_impl.h: In member function 'std::size_t Hal::Serial::write(uint8_t)':
avionics/envs/board/lib/HAL/port_impl.h:16:57: warning: no return statement in function returning non-void [-Wreturn-type]
     std::size_t write(uint8_t val) { m_seri.write(val); }
```